### PR TITLE
Prevent blank notifications when up-to-date

### DIFF
--- a/bin/brew-auto-update
+++ b/bin/brew-auto-update
@@ -48,6 +48,7 @@ else
 fi
 
 outdated=$(brew outdated | tr '\n' ' ' | sed 's/ $//')
+notifications=$(terminal-notifier -list org.eisentraut.BrewAutoUpdate)
 
 if $updated && [ -n "$outdated" ]; then
 	if [ "$auto_fetch" = 1 ]; then
@@ -61,6 +62,6 @@ if $updated && [ -n "$outdated" ]; then
 		-message "$outdated" \
 		-activate "$termapp_id" \
 		>/dev/null
-elif [ -z "$outdated" ]; then
+elif [ -z "$outdated" ] && [ -n "$notifications" ]; then
 	terminal-notifier -remove 'org.eisentraut.BrewAutoUpdate' >/dev/null
 fi


### PR DESCRIPTION
Removing notifications from terminal-notifier is buggy. When there are
no notifications to remove, it sometimes creates a new, blank
notification instead.

This commit prevents those distracting empty notifications by checking
whether any notifications exist before attempting to remove them.

This fixes #1.
